### PR TITLE
deps - bump ws

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,6 +1,6 @@
 'use strict';
 var ws = require('pull-ws')
-var WebSocket = require('ws')
+var WebSocket = global.WebSocket || require('ws')
 var wsurl = require('./ws-url')
 
 function isFunction (f) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var ws = require('pull-ws')
-var WebSocket = require('ws')
+var WebSocket = global.WebSocket || require('ws')
 var url = require('url')
 var http = require('http')
 var https = require('https')

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "pull-ws": "^2.3.0",
     "relative-url": "^1.0.0",
-    "ws": "git://github.com/dominictarr/ws.git#590d0ea0d62b0c533cd6f26ff0e3f31f946a80db"
+    "ws": "^1.1.0"
   },
   "devDependencies": {
     "pull-json-doubleline": "^1.0.0",
@@ -22,7 +22,9 @@
   "scripts": {
     "test": "set -e; for t in test/*.js; do node $t; done"
   },
-  "browser": "./client.js",
+  "browser": {
+    "ws": false
+  },
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (http://dominictarr.com)",
   "license": "MIT"
 }


### PR DESCRIPTION
Fixes https://github.com/pull-stream/pull-ws-server/issues/17

This is a breaking change:
* `ws` no longer supports the browser and older nodes https://github.com/websockets/ws/releases/tag/1.0.0
* so we dont include `ws` in the browser
* but this means the browser entrypoint is not automatically update to `./client.js` due to a browserify api limitation ( cant override the main AND ignore deps ). This means browser consumers must explicitly require (`pull-ws-server/client`). Module consumers may need to change to import the correct file. I think this is good though, because `client.js` and `index.js` have a totally different api - we should be more explicit and less magical here.